### PR TITLE
Hotfix/transform source path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+## [1.1.1] - 2020-11-16
+
+### Fixed
+
+- changed `$asset->url` to `$asset->getImageTransformSourcePath()` ([#3](https://github.com/codewithkyle/craft-jitter/issues/3))
+
 ## [1.1.0] - 2020-10-26
 
 ### Added
@@ -26,6 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
     - delete local files
     - delete S3 files
 
-[Unreleased]: https://github.com/codewithkyle/craft-jitter/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/codewithkyle/craft-jitter/compare/v1.1.1...HEAD
+[1.1.`]: https://github.com/codewithkyle/craft-jitter/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/codewithkyle/craft-jitter/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/codewithkyle/craft-jitter/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 
 - changed `$asset->url` to `$asset->getImageTransformSourcePath()` ([#3](https://github.com/codewithkyle/craft-jitter/issues/3))
+- changed file extension regex pattern from `/(\..*)$/` to `/(\..{1,4})$/` ([#3](https://github.com/codewithkyle/craft-jitter/issues/3))
 
 ## [1.1.0] - 2020-10-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
-## [1.1.1] - 2020-11-16
+## [1.1.1] - 2020-11-19
 
 ### Fixed
 
@@ -34,6 +34,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
     - delete S3 files
 
 [Unreleased]: https://github.com/codewithkyle/craft-jitter/compare/v1.1.1...HEAD
-[1.1.`]: https://github.com/codewithkyle/craft-jitter/compare/v1.1.0...v1.1.1
+[1.1.1]: https://github.com/codewithkyle/craft-jitter/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/codewithkyle/craft-jitter/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/codewithkyle/craft-jitter/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -67,18 +67,19 @@ Requesting an image transformation via Twig:
 
 Transformation parameters:
 
-| Parameter     | Default                  | Description                     | Valid options                          |
-| ------------- | ------------------------ | ------------------------------- | -------------------------------------- |
-| `id`          | `null`                   | the image asset id (required)   | `int`                                  |
-| `w`           | base image width         | desired image width             | `int`                                  |
-| `h`           | base image height        | desired image height            | `int`                                  |
-| `ar`          | base image aspect ratio  | desired aspect ratio            | `int:int`                              |
-| `fm`          | `auto`                   | desired image format            | `jpg`, `png`, `gif`, `auto`            |
-| `q`           | `80`                     | desired image quality           | `0` to `100`                           |
-| `m`           | `clip`                   | how the image should be resized | `crop`, `clip`, `fit`, `letterbox`     |
-| `bg`          | `ffffff`                 | letterbox background color      | `hex`                                  |
-| `fp-x`        | `0.5`                    | horizontal focus point          | `0` to `1`                             |
-| `fp-y`        | `0.5`                    | vertical focus point            | `0` to `1`                             |
+| Parameter     | Default                    | Description                     | Valid options                          |
+| ------------- | -------------------------- | ------------------------------- | -------------------------------------- |
+| `id`          | `null`                     | the image asset id              | `int`                                  |
+| `path`        | `null`                     | the image asset id              | `int`                                  |
+| `w`           | base image width           | desired image width             | `int`                                  |
+| `h`           | base image height          | desired image height            | `int`                                  |
+| `ar`          | base image aspect ratio    | desired aspect ratio            | `int`:`int`                            |
+| `fm`          | `auto`                     | desired image format            | `jpg`, `png`, `gif`, `auto`            |
+| `q`           | `80`                       | desired image quality           | `0` to `100`                           |
+| `m`           | `clip`                     | how the image should be resized | `crop`, `clip`, `fit`, `letterbox`     |
+| `bg`          | `ffffff`                   | letterbox background color      | `hex`                                  |
+| `fp-x`        | `0.5` or asset focal point | horizontal focus point          | `0` to `1`                             |
+| `fp-y`        | `0.5` or asset focal point | vertical focus point            | `0` to `1`                             |
 
 The `auto` format type will return a `webp` image when the server can generate the format and the client's browser supports the format.
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "codewithkyle/jitter",
     "description": "A just in time image transformation service.",
     "type": "craft-plugin",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "keywords": [
         "craft",
         "cms",

--- a/src/services/Transform.php
+++ b/src/services/Transform.php
@@ -94,7 +94,7 @@ class Transform extends Component
         }
         else
         {
-            $masterImage = $asset->url;
+            $masterImage = $asset->getImageTransformSourcePath();
         }
         if ($masterImage)
         {
@@ -165,7 +165,7 @@ class Transform extends Component
             }
             else
             {
-                $masterImage = $asset->url;
+                $masterImage = $asset->getImageTransformSourcePath();
             }
         }
         else if (isset($params['path']))

--- a/src/services/Transform.php
+++ b/src/services/Transform.php
@@ -173,13 +173,13 @@ class Transform extends Component
             $masterImage = $params['path'];
         }
 
-        preg_match("/(\..*)$/", $asset->filename, $matches);
+        preg_match("/(\..{1,4})$/", $asset->filename, $matches);
         $baseType = strtolower(ltrim($matches[0], "."));
 
         // Build transform details
         $transform = $this->getImageTransformSettings($params, $masterImage, $asset);
         $uid = $this->buildTransformUid($transform);
-        $filename = preg_replace("/(\..*)$/", '', $asset->filename) . '-' . $uid;
+        $filename = preg_replace("/(\..{1,4})$/", '', $asset->filename) . '-' . $uid;
 
         // Create S3 client (if possible)
         $settings = [];
@@ -225,7 +225,7 @@ class Transform extends Component
                 $cleanName = preg_replace("/.*\//", '', $cleanName);
                 $response['url'] = "/jitter/" . $cleanName;
                 $response['type'] = 'local';
-                preg_match("/(\..*)$/", $existingFile, $matches);
+                preg_match("/(\..{1,4})$/", $existingFile, $matches);
                 $contentType = ltrim($matches[0], ".");
                 switch ($contentType)
                 {
@@ -253,7 +253,7 @@ class Transform extends Component
         // Save the output
         if ($s3)
         {
-            preg_match("/(\..*)$/", $finalImage, $matches);
+            preg_match("/(\..{1,4})$/", $finalImage, $matches);
             $finalImageType = $matches[0];
             $uri = "/" . str_replace('\\', '/', $finalImage);
             $uri = preg_replace("/.*\//", '', $uri);
@@ -288,7 +288,7 @@ class Transform extends Component
             copy($finalImage, FileHelper::normalizePath($publicPath. DIRECTORY_SEPARATOR  . $cleanName));
             $response['url'] = "/jitter/" . $cleanName;
             $response['type'] = 'local';
-            preg_match("/(\..*)$/", $finalImage, $matches);
+            preg_match("/(\..{1,4})$/", $finalImage, $matches);
             $contentType = ltrim($matches[0], ".");
             switch ($contentType)
             {


### PR DESCRIPTION
### Fixed

- changed `$asset->url` to `$asset->getImageTransformSourcePath()` ([#3](https://github.com/codewithkyle/craft-jitter/issues/3))
- changed file extension regex pattern from `/(\..*)$/` to `/(\..{1,4})$/` ([#3](https://github.com/codewithkyle/craft-jitter/issues/3))