### PR TITLE
v2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+## [2.3.0] - 2022-08-23
+
+### Added
+
+- CDN support ([#22](https://github.com/codewithkyle/craft-jitter/issues/22))
+- automatically delete transformed images when the source image is deleted from Craft ([#19](https://github.com/codewithkyle/craft-jitter/issues/19))
+- new config settings:
+    - `cdn`
+        - must be the CDN's origin URL
+    - `acl`
+        - controls the files default ACL value
+        - supports "private" (default) and "public-read"
+
+### Fixed
+
+- images stored in S3 or Spaces now use the correct `Content-Type` header ([#21](https://github.com/codewithkyle/craft-jitter/issues/21))
+    - previously always used `application/octet-stream` (default value for S3-compatible storage solutions)
+    - now uses correct MIME type
+
 ## [2.2.0] - 2022-07-07
 
 ### Added
@@ -130,7 +149,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
     - delete local files
     - delete S3 files
 
-[Unreleased]: https://github.com/codewithkyle/craft-jitter/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/codewithkyle/craft-jitter/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/codewithkyle/craft-jitter/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/codewithkyle/craft-jitter/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/codewithkyle/craft-jitter/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/codewithkyle/craft-jitter/compare/v1.2.6...v2.0.0

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Jitter is a just in time image transformation plugin for Craft CMS. The API is b
 
 This plugin requires [ImageMagick](https://imagemagick.org/index.php) and the following versions of PHP and Craft CMS:
 
-- Craft CMS 4.0.0+ with PHP 8+
-- Craft CMS 3.0.0+ with PHP 7.2+ or 8+
+- Craft CMS 4.0.0+ with PHP 8+ (Jitter v2.0+, active)
+- Craft CMS 3.0.0+ with PHP 7.2+ (Jitter v1.x, unsupported)
 
 ## Installation
 
@@ -36,11 +36,33 @@ return [
     "region" => "region-name",
     "bucket" => "bucket-name",
     "folder" => "transformed-images",
-    "endpoint" => getenv("ENDPOINT_URL")
+    "endpoint" => getenv("ENDPOINT_URL"),
+    "acl" => "private", // supports "private" or "public-read"
 ];
 ```
 
-> **Note**: the `endpoint` config value is optional. You will only need to use it when using an S3-compatible alternative S3 cloud object storage solution (like Digital Ocean Spaces).
+> **Note**: the `endpoint` and `acl` config values are optional. You will only need to use `endpoint` when using an S3-compatible alternative S3 cloud object storage solution (like Digital Ocean Spaces).
+
+## CDN
+
+Jitter can be configured to use CDN URLs. The `cdn` config value should be the CDN's origin URL. Jitter's `url()` and `srcset()` functions will automatically switch from using the `/jitter/` URL to the CDN URL over time as the image transformations are performed.
+
+```php
+<?php
+
+return [
+    "accessKey" => getenv("PUBLIC_KEY"),
+    "secretAccessKey" => getenv("PRIVATE_KEY"),
+    "region" => "region-name",
+    "bucket" => "bucket-name",
+    "folder" => "transformed-images",
+    "endpoint" => getenv("ENDPOINT_URL"),
+    "acl" => "public-read",
+    "cdn" => "https://demo.cdn.example.com/"
+];
+```
+
+> **Note**: if you use Craft's template caching or a 3rd party HTML caching service (like Cloudflare's Edge Cache) `/jitter/` image URLs may be cached when a CDN URL is available. We do not recommend disabling your caching systems, however, you may want to consider settings a lower TTL to ensure the CDN URLs propagate sooner rather than later.
 
 ## Using Jitter
 
@@ -58,6 +80,7 @@ Requesting an image transformation via Twig:
 {% set transformedImageUrl = craft.jitter.transformImage(entry.image[0], { w: 150, ar: "1:1", m: "fit", fm: "gif", q: 10 }) %}
 
 {# For a faster template render build the API URL instead #}
+{# If you have configured Jitter to use CDN URLs this value will switch to the CDN URL after the image has been transformed #}
 {% set transformedImageUrl = craft.jitter.url(entry.image[0], { w: 150, ar: "1:1", m: "fit", fm: "gif", q: 10 }) %}
 
 <img 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To install the plugin, follow these instructions.
 
 ## Configuring Jitter
 
-Jitter can be configured to use S3-compatible object storage solutions by adding a `jitter.php` file to your projects `config/` directory.
+Jitter can be configured to use S3-compatible object storage solutions by adding a `jitter.php` file to your projects `config/` directory. Transformed images will be stored in the storage solution but will still be served from your web server. If you would like to server images from a CDN read the section below.
 
 ```php
 <?php
@@ -62,7 +62,7 @@ return [
 ];
 ```
 
-> **Note**: if you use Craft's template caching or a 3rd party HTML caching service (like Cloudflare's Edge Cache) `/jitter/` image URLs may be cached when a CDN URL is available. We do not recommend disabling your caching systems, however, you may want to consider settings a lower TTL to ensure the CDN URLs propagate sooner rather than later.
+> **Note**: if you use Craft's template caching or a 3rd party HTML caching service (like Cloudflare's Edge Cache) `/jitter/` image URLs may be cached when a CDN URL is available. We do not recommend disabling your caching systems, however, you may want to consider using a lower TTL to ensure the CDN URLs propagate sooner rather than later.
 
 ## Using Jitter
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To install the plugin, follow these instructions.
 
 ## Configuring Jitter
 
-Jitter can be configured to use S3-compatible object storage solutions by adding a `jitter.php` file to your projects `config/` directory. Transformed images will be stored in the storage solution but will still be served from your web server. If you would like to server images from a CDN read the section below.
+Jitter can be configured to use S3-compatible object storage solutions by adding a `jitter.php` file to your projects `config/` directory. Transformed images will be stored in the storage solution but will still be served from your web server. If you would like to serve images from a CDN read the section below.
 
 ```php
 <?php
@@ -43,7 +43,7 @@ return [
 
 > **Note**: the `endpoint` and `acl` config values are optional. You will only need to use `endpoint` when using an S3-compatible alternative S3 cloud object storage solution (like Digital Ocean Spaces).
 
-## CDN
+## Using a Content Delivery Network (CDN)
 
 Jitter can be configured to use CDN URLs. The `cdn` config value should be the CDN's origin URL. Jitter's `url()` and `srcset()` functions will automatically switch from using the `/jitter/` URL to the CDN URL over time as the image transformations are performed.
 
@@ -66,13 +66,13 @@ return [
 
 ## Using Jitter
 
-Requesting an image transformation through the API:
+Image transformations via the API:
 
 ```
 /jitter/v1/transform?id=1&w=768&ar=16:9
 ```
 
-Requesting an image transformation via Twig:
+Image transformations via Twig:
 
 ```twig
 {# This will transform the image when the template renders. #}
@@ -80,7 +80,7 @@ Requesting an image transformation via Twig:
 {% set transformedImageUrl = craft.jitter.transformImage(entry.image[0], { w: 150, ar: "1:1", m: "fit", fm: "gif", q: 10 }) %}
 
 {# For a faster template render build the API URL instead #}
-{# If you have configured Jitter to use CDN URLs this value will switch to the CDN URL after the image has been transformed #}
+{# If you have configured Jitter to use CDN URLs this value will swap to the CDN URL after the image has been transformed #}
 {% set transformedImageUrl = craft.jitter.url(entry.image[0], { w: 150, ar: "1:1", m: "fit", fm: "gif", q: 10 }) %}
 
 <img 
@@ -95,7 +95,7 @@ Requesting an image transformation via Twig:
 />
 ```
 
-Generating transformations via PHP:
+Image transformations via PHP:
 
 ```php
 $jitter = new \codewithkyle\jitter\services\Transform();
@@ -120,7 +120,7 @@ $srcset = $jitter->generateSourceSet($image, [
 ]);
 ```
 
-Transformation parameters:
+## Transformation parameters
 
 | Parameter     | Default                    | Description                     | Valid options                                  |
 | ------------- | -------------------------- | ------------------------------- | ---------------------------------------------- |

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "codewithkyle/jitter",
     "description": "A just in time image transformation service.",
     "type": "craft-plugin",
-    "version": "2.2.1",
+    "version": "2.3.0",
     "keywords": [
         "craft",
         "cms",

--- a/src/Jitter.php
+++ b/src/Jitter.php
@@ -15,6 +15,7 @@ use codewithkyle\jitter\variables\JitterVariable;
 
 use Craft;
 use craft\base\Plugin;
+use craft\elements\Asset;
 use craft\services\Plugins;
 use craft\events\PluginEvent;
 use craft\web\UrlManager;
@@ -97,6 +98,16 @@ class Jitter extends Plugin
                         }
                     }
                 ];
+            }
+        );
+
+        // Register delete event logic
+        Event::on(
+            Asset::class,
+            Asset::EVENT_BEFORE_DELETE,
+            function ($e) {
+                $asset = $e->sender;
+                Jitter::getInstance()->transform->clearImageTransforms($asset);
             }
         );
 

--- a/src/services/Transform.php
+++ b/src/services/Transform.php
@@ -253,11 +253,12 @@ class Transform extends Component
         }
         JitterCore::TransformImage($tempImage, $transform, $resizeOn);
 
-        $this->cacheImage($settings, $key, $tempImage);
+        $mime = \mime_content_type($tempImage),
+        $this->cacheImage($settings, $key, $tempImage, $mime);
 
         $file = [
             "Body" => \file_get_contents($tempImage),
-            "ContentType" => \mime_content_type($tempImage),
+            "ContentType" => $mime,
             "Name" => $key,
         ];
 
@@ -363,7 +364,7 @@ class Transform extends Component
         return (array)$response;
     }
 
-    private function cacheImage($settings, $key, $image): void
+    private function cacheImage($settings, $key, $image, $mime): void
     {
         if (!empty($settings))
         {
@@ -376,6 +377,7 @@ class Transform extends Component
                 'Bucket' => $settings['bucket'],
                 'Key' => $s3Key,
                 'SourceFile' => $image,
+                'ContentType' => $mime,
             ]);
             touch(FileHelper::normalizePath($this->getTempPath() . "/" . $key));
         }

--- a/src/services/Transform.php
+++ b/src/services/Transform.php
@@ -190,10 +190,22 @@ class Transform extends Component
         return $ret;
     }
 
-    public function transformImage(array $params, Asset $asset = null): array
+    public function transformImage(array $params, ?Asset $asset = null): array
     {
         $transform = JitterCore::BuildTransform($params);
-        $key = $this->createKey($params, $asset);
+        $assetOrId = $asset;
+        if (is_null($assetOrId))
+        {
+            if (issset($params["id"]))
+            {
+                $assetOrId = $params["id"];
+            }
+            else
+            {
+                $assetOrId = $params["path"];
+            }
+        }
+        $key = $this->createKey($transform, $assetOrId);
         $settings = $this->getSettings();
 
         // Caching logic
@@ -387,21 +399,17 @@ class Transform extends Component
         }
     }
 
-    private function createKey(array $params, ?Asset $asset): string
+    private function createKey(array $transform, Asset|string $assetOrId): string
     {
-        $assetIndent = null;
-        if (!is_null($asset))
+        $id = null;
+        if ($assetOrId instanceof Asset)
         {
-            $assetIndent = $asset->id;
+            $id = $asset->id;
         }
-        else if (isset($params["id"]))
+        else
         {
-            $assetIndent = $params["id"];
+            $id = $assetOrId;
         }
-        else if (isset($params["path"]))
-        {
-            $assetIndent = $params["path"];
-        }
-        return $this->buildTransformUid($assetIndent, $params);
+        return $this->buildTransformUid($id, $transform);
     }
 }

--- a/src/services/Transform.php
+++ b/src/services/Transform.php
@@ -113,6 +113,26 @@ class Transform extends Component
 
     public function generateURL(array $params): string
     {
+        // Return early if we are using a CDN && the transform has already been created
+        $settings = $this->getSettings();
+        if (isset($settings["cdn"]))
+        {
+            $transform = JitterCore::BuildTransform($params);
+            $key = $this->createKey($transform, $params["id"]);
+            $path = FileHelper::normalizePath($this->getTempPath() . "/" . $key);
+            if (\file_exists($path))
+            {
+                $ret = rtrim($settings["cdn"], "/") . "/";
+                if (isset($settings["folder"]))
+                {
+                    $ret .= trim($settings["folder"], "/") . "/";
+                }
+                $ret .= $key;
+                return $ret;
+            }
+        }
+
+        // If not using CDN or the transform doesn't exist (yet) use local URL
         $ret = "/jitter/v1/transform?";
         foreach ($params as $key => $value)
         {
@@ -142,6 +162,12 @@ class Transform extends Component
         }
 
         $baseUrl = "/jitter/v1/transform?id=" . $id;
+        $cdnUrl = null;
+        $settings = $this->getSettings();
+        if (isset($settings["cdn"]))
+        {
+            $cdnUrl = rtrim($settings["cdn"], "/") . "/";
+        }
 
         if (!empty($asset))
         {
@@ -150,11 +176,33 @@ class Transform extends Component
             foreach ($images as $image)
             {
                 $count++;
-                $ret .= $baseUrl;
-                foreach ($image as $key => $value)
+                $usedCDN = false;
+
+                if (!is_null($cdnUrl))
                 {
-                    $ret .= "&" . $key . "=" . $value;
+                    $transform = JitterCore::BuildTransform($image);
+                    $key = $this->createKey($transform, $id);
+                    $path = FileHelper::normalizePath($this->getTempPath() . "/" . $key);
+                    if (\file_exists($path))
+                    {
+                        $ret .= $cdnUrl;
+                        if (isset($settings["folder"]))
+                        {
+                            $ret .= trim($settings["folder"], "/") . "/";
+                        }
+                        $ret .= $key;
+                        $usedCDN = true;
+                    }
                 }
+                if (!$usedCDN)
+                {
+                    $ret .= $baseUrl;
+                    foreach ($image as $key => $value)
+                    {
+                        $ret .= "&" . $key . "=" . $value;
+                    }
+                }
+
                 if (isset($image['w']))
                 {
                     $ret .= " " . $image['w'] . "w";
@@ -209,10 +257,9 @@ class Transform extends Component
         $settings = $this->getSettings();
 
         // Caching logic
-        $cachedResponse = $this->checkCache($settings, $key);
-        if (!empty($cachedResponse))
+        if ($this->checkCache($settings, $key))
         {
-            return $cachedResponse;
+            return $this->getCachedImage($settings, $key);
         }
 
         // Transform logic
@@ -340,7 +387,7 @@ class Transform extends Component
         return $path;
     }
 
-    private function checkCache($settings, string $key): array
+    private function getCachedImage(array $settings, string $key): array
     {
         $response = [];
         if (!empty($settings))
@@ -376,6 +423,28 @@ class Transform extends Component
         return (array)$response;
     }
 
+    private function checkCache(array $settings, string $key): bool
+    {
+        $isCached = false;
+        if (!empty($settings))
+        {
+            $path = FileHelper::normalizePath($this->getTempPath() . "/" . $key);
+            if (\file_exists($path))
+            {
+                $isCached = true;
+            }
+        }
+        else
+        {
+            $path = FileHelper::normalizePath($this->getPublicPath() . "/" . $key);
+            if (\file_exists($path))
+            {
+                $isCached = true;
+            }
+        }
+        return $isCached;
+    }
+
     private function cacheImage($settings, $key, $image, $mime): void
     {
         if (!empty($settings))
@@ -386,10 +455,11 @@ class Transform extends Component
                 $s3Key = $settings['folder'] . "/" . $key;
             }
             $s3->putObject([
-                'Bucket' => $settings['bucket'],
-                'Key' => $s3Key,
-                'SourceFile' => $image,
-                'ContentType' => $mime,
+                "Bucket" => $settings['bucket'],
+                "Key" => $s3Key,
+                "SourceFile" => $image,
+                "ContentType" => $mime,
+                "ACL" => $settings["acl"] ?? "private",
             ]);
             touch(FileHelper::normalizePath($this->getTempPath() . "/" . $key));
         }

--- a/src/services/Transform.php
+++ b/src/services/Transform.php
@@ -27,6 +27,59 @@ class Transform extends Component
 {
     // Public Methods
     // =========================================================================
+    
+    public function clearImageTransforms(Asset $image): void
+    {
+        $settings = $this->getSettings();
+        $uid = \md5($image->id);
+        if (!empty($settings))
+        {
+            $dirname = $this->getTempPath();
+            if (\file_exists($dirname))
+            {
+                $s3 = $this->connectToS3($settings);
+                $files = \scandir($dirname);
+                foreach ($files as $key => $value)
+                {
+                    if ($value != '.' && $value != '..')
+                    {
+                        $segments = explode("-", $value);
+                        if ($segments[0] == $uid)
+                        {
+                            $s3Key = $value;
+                            if (isset($settings['folder']))
+                            {
+                                $s3Key = $settings['folder'] . "/" . $value;
+                            }
+                            $s3->deleteObject([
+                                'Bucket' => $settings['bucket'],
+                                'Key'    => $s3Key,
+                            ]);
+                            $filePath = FileHelper::normalizePath($dirname . "/" . $value);
+                            \unlink($filePath);
+                        }
+                    }
+                }
+            }
+        }
+        else
+        {
+            $publicDir = FileHelper::normalizePath(Yii::getAlias('@webroot') . "/jitter");
+            $files = \scandir($publicDir);
+            foreach ($files as $key => $value)
+            {
+                if ($value != '.' && $value != '..')
+                {
+                    $segments = explode("-", $value);
+                    if ($segments[0] == $uid)
+                    {
+                        $filePath = FileHelper::normalizePath($publicDir . "/" . $value);
+                        \unlink($filePath);
+                    }
+                }
+            }
+        }
+    }
 
     public function clearS3BucketCache(): void
     {


### PR DESCRIPTION
### Added

- CDN support ([#22](https://github.com/codewithkyle/craft-jitter/issues/22))
- automatically delete transformed images when the source image is deleted from Craft ([#19](https://github.com/codewithkyle/craft-jitter/issues/19))
- new config settings:
   - `cdn`
       - must be the CDN's origin URL
   - `acl`
       - controls the files default ACL value
       - supports `"private"` (default) and `"public-read"`

### Fixed

- images stored in S3 or Spaces now use the correct `Content-Type` header ([#21](https://github.com/codewithkyle/craft-jitter/issues/21))
   - previously always used `application/octet-stream` (default value for S3-compatible storage solutions)
   - now uses correct MIME type